### PR TITLE
workflow to manual trigger build and publish for GHCR.

### DIFF
--- a/.github/workflows/build-publish-ghcr.yaml
+++ b/.github/workflows/build-publish-ghcr.yaml
@@ -1,0 +1,44 @@
+# This is a basic workflow to help you get started with Actions
+
+name: GHCR Bundle Build
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+ on: [workflow_dispatch]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Lowercase my github ownername.
+      - name: Set Environment Variables
+        run: |
+          OWNER="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          echo "REPO-OWNER=${OWNER}" >> $GITHUB_ENV
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+     
+      - name: Setup Porter
+        # You may pin to the exact commit or the version.
+        # uses: getporter/gh-action@d8539f57d75587d98651fc94de9e7e63abfaf75e
+        uses: getporter/gh-action@v0.1.3 # 1.3 is the latest version
+      - name: Porter Build Project
+        run: |
+          porter build
+
+      - name: Login to GitHub Packages OCI Registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Porter publish to ghcr.io 
+      # Note the below automatically sets the registry to the local GH registry of the org name. 
+      # Currently, for pure gitops reconstructing this runtime setting will require looking at the repository owner of the commit
+        run: |
+          porter publish --registry ghcr.io/${{ env.REPO-OWNER }} --debug


### PR DESCRIPTION
This is for the new workflow which could be manually triggered `GHCR` build and publish step, just something extra. 

From upstream I cam e to know this as one of the ways to publish images as well, hnece worth adding this as well.

Thanks heaps, ☕️🙏 
cc: @rzhang628 